### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://gisari.visualstudio.com/74408308-1d54-4db1-8edc-c51c8caa7b7b/0d6d88da-cfbc-4e0b-8275-5f7398e5edf6/_apis/work/boardbadge/42a81ba5-6180-423f-970c-e18e549ad35e)](https://gisari.visualstudio.com/74408308-1d54-4db1-8edc-c51c8caa7b7b/_boards/board/t/0d6d88da-cfbc-4e0b-8275-5f7398e5edf6/Microsoft.RequirementCategory)
 # randomit
 
 ## Project setup


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://gisari.visualstudio.com/74408308-1d54-4db1-8edc-c51c8caa7b7b/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.